### PR TITLE
Fix typo 'abilties'

### DIFF
--- a/Lua Command Reference/LAURA II Lua Commands.html
+++ b/Lua Command Reference/LAURA II Lua Commands.html
@@ -404,7 +404,7 @@ end</pre>
 </p><hr><a id='Image.DontUseSpecial' name='Image.DontUseSpecial'></a><h1>Image.DontUseSpecial</h1><table width=80%><tr><td class=head colspan=2 align=center>Overview</td></tr>
 <tr valign=top class=info><td width=200>Name</td><td>Image.DontUseSpecial</td></tr>
 <tr valign=top class=info><td width=200>Type</td><td>Variable</td></tr>
-</table><p> When set to 1 the Special load abilties of Image.Load will be ignored. When set to 0, everything will load
+</table><p> When set to 1 the Special load abilities of Image.Load will be ignored. When set to 0, everything will load
 </p><hr><a id='Image.Draw' name='Image.Draw'></a><h1>Image.Draw</h1><table width=80%><tr><td class=head colspan=2 align=center>Overview</td></tr>
 <tr valign=top class=info><td width=200>Name</td><td>Image.Draw</td></tr>
 <tr valign=top class=info><td width=200>Type</td><td>Method</td></tr>


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abilities', you typed 'abilties'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
